### PR TITLE
remove user token instructions for nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,6 @@ Apache Nexus repository is located at [repository.apache.org](https://repository
 
 1. Login with Apache Credentials
 2. Confirm access to `org.apache.systemds` by visiting https://repository.apache.org/#stagingProfiles;1486a6e8f50cdf
-3. Go to `Profile` (top right dropdown menu). Choose `User Token` from dropdown, then select `Access User Token`. Copy the Maven XML configuration block.
-4. This token will be used in `settings.xml`
 
 
 ## Add future release version to JIRA


### PR DESCRIPTION
Since we are using REST API with LDAP credentials.

https://github.com/j143/release-scripts/blob/8e7fe646744631f5e8c12e63cffd75e89a2dff4d/release-build.sh#L134-L137