### PR TITLE
-Dmaven.deploy.skip=true dryRun for mvn deploy

### DIFF
--- a/release-build.sh
+++ b/release-build.sh
@@ -75,7 +75,7 @@ EOF
 
 if [[ "$1" == "publish-snapshot" ]]; then
   
-  mvn --settings tmp-settings.xml deploy -DskipTests -DdryRun="${dry_run}" \
+  mvn --settings tmp-settings.xml deploy -DskipTests -Dmaven.deploy.skip="${dry_run}" \
     -DaltSnapshotDeploymentRepository=github::default::https://maven.pkg.github.com/j143/systemds \
     ${GPG_OPTS}
 


### PR DESCRIPTION
Just like `-Dmaven.tests.skip=true` to skip tests. use `-Dmaven.deploy.skip=true`

https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html

Releated discussion:
https://stackoverflow.com/a/11322263 for -Dmaven.deploy.skip=true