### PR TITLE
temp gpg key generate for testing

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,6 +36,7 @@ jobs:
     - name: gpg key generation - transient
       run: |
         export GNUPGHOME="/home/runner/.gnupg"
+        ls *
         cat >tempkey <<EOF
           %echo Generating a basic OpenPGP key
           Key-Type: DSA
@@ -65,6 +66,7 @@ jobs:
         cd systemds
         ls *
         export GNUPGHOME="/home/runner/.gnupg"
+        ls $GNUPGHOME
         bash $GITHUB_WORKSPACE/do-release.sh
       env:
         DRY_RUN: '1'
@@ -73,7 +75,7 @@ jobs:
         ASF_USERNAME: 'firstname'
         GIT_NAME: 'Firstname Lastname'
         GIT_EMAIL: 'j143+[bot]@protonmail.com'
-        GPG_KEY: '${{ env.GPG_KEY_ID }}'
+        GPG_KEY: 'j143+[bot]@protonmail.com'
         CORRECT_RELEASE_INFO: '1'
         ASF_PASSWORD: asdfghjkl # wrong password, only to run this workflow
         GPG_PASSPHRASE: asdfghjkl # wrong passphrase, only to run this workflow

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -67,6 +67,8 @@ jobs:
         ls *
         export GNUPGHOME="/home/runner/.gnupg"
         ls $GNUPGHOME
+        GPG_KEY_ID="$(gpg --list-keys | head -n 4 | tail -n 1 | sed 's/^ *//g')"
+        export GPG_KEY=$GPG_KEY_ID
         bash $GITHUB_WORKSPACE/do-release.sh
       env:
         DRY_RUN: '1'
@@ -75,7 +77,6 @@ jobs:
         ASF_USERNAME: 'firstname'
         GIT_NAME: 'Firstname Lastname'
         GIT_EMAIL: 'j143+[bot]@protonmail.com'
-        GPG_KEY: '${{ env.GPG_KEY_ID }}'
         CORRECT_RELEASE_INFO: '1'
         ASF_PASSWORD: 'asdfghjkl' # wrong password, only to run this workflow
         GPG_PASSPHRASE: 'asdfghjkl' # wrong passphrase, only to run this workflow

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -71,7 +71,7 @@ jobs:
         ASF_USERNAME: 'firstname'
         GIT_NAME: 'Firstname Lastname'
         GIT_EMAIL: 'j143+[bot]@protonmail.com'
-        GPG_KEY: '${{ GPG_KEY_ID }}'
+        GPG_KEY: '${{ env.GPG_KEY_ID }}'
         CORRECT_RELEASE_INFO: '1'
         ASF_PASSWORD: asdfghjkl # wrong password, only to run this workflow
         GPG_PASSPHRASE: asdfghjkl # wrong passphrase, only to run this workflow

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -54,7 +54,7 @@ jobs:
     
     - run: |
         gpg --list-keys
-        GPG_KEY="$(gpg --list-keys | head -n 4 | tail -n 1 | sed 's/^ *//g')"
+        GPG_KEY_ID="$(gpg --list-keys | head -n 4 | tail -n 1 | sed 's/^ *//g')"
     
     - name: Run invoke script
       run: |
@@ -71,6 +71,7 @@ jobs:
         ASF_USERNAME: 'firstname'
         GIT_NAME: 'Firstname Lastname'
         GIT_EMAIL: 'j143+[bot]@protonmail.com'
+        GPG_KEY: '${{ GPG_KEY_ID }}'
         CORRECT_RELEASE_INFO: '1'
         ASF_PASSWORD: asdfghjkl # wrong password, only to run this workflow
         GPG_PASSPHRASE: asdfghjkl # wrong passphrase, only to run this workflow

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -70,7 +70,9 @@ jobs:
         ls *
         export GNUPGHOME="/home/runner/.gnupg"
         ls $GNUPGHOME
-        export GPG_KEY=${{ env.GPG_KEY_ID }}
+        GPG_KEY_FINGERPRINT="$(gpg --list-keys | head -n 4 | tail -n 1 | sed 's/^ *//g')"
+        GPG_KEY_ID="${GPG_KEY_FINGERPRINT: (-8)}"
+        export GPG_KEY=$GPG_KEY_ID
         bash $GITHUB_WORKSPACE/do-release.sh
       env:
         DRY_RUN: '1'

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -35,7 +35,7 @@ jobs:
     
     - name: gpg key generation - transient
       run: >
-        export GNUPGHOME="$(mktemp -d)"
+        export GNUPGHOME="$(mktemp -d)";
         cat >tempkey <<EOF
           %echo Generating a basic OpenPGP key
           Key-Type: DSA
@@ -50,7 +50,7 @@ jobs:
           # Do a commit here, so that we can later print "done" :-)
           %commit
           %echo done
-        EOF
+        EOF;
         gpg --batch --generate-key tempkey
     
     - name: Run invoke script

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -64,6 +64,7 @@ jobs:
         git clone https://github.com/j143/systemds
         cd systemds
         ls *
+        export GNUPGHOME="/home/runner/.gnupg"
         bash $GITHUB_WORKSPACE/do-release.sh
       env:
         DRY_RUN: '1'

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -54,9 +54,12 @@ jobs:
         EOF
         gpg --batch --generate-key tempkey
     
-    - run: |
+    # the last eight digits of the finger print is key id
+    - name: Set the GPG key ID
+      run: |
         gpg --list-keys
-        GPG_KEY_ID="$(gpg --list-keys | head -n 4 | tail -n 1 | sed 's/^ *//g')"
+        GPG_KEY_FINGERPRINT="$(gpg --list-keys | head -n 4 | tail -n 1 | sed 's/^ *//g')"
+        GPG_KEY_ID="${GPG_KEY_FINGERPRINT: (-8)}"
     
     - name: Run invoke script
       run: |

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -35,7 +35,8 @@ jobs:
     
     - name: gpg key generation - transient
       run: |
-        export GNUPGHOME="/home/runner/.gnupg"
+        printf "HOME: $HOME \n"
+        export GNUPGHOME="$HOME/.gnupg"
         ls *
         cat >tempkey <<EOF
           %echo Generating a basic OpenPGP key
@@ -68,7 +69,7 @@ jobs:
         git clone https://github.com/j143/systemds
         cd systemds
         ls *
-        export GNUPGHOME="/home/runner/.gnupg"
+        export GNUPGHOME="$HOME/.gnupg"
         ls $GNUPGHOME
         GPG_KEY_FINGERPRINT="$(gpg --list-keys | head -n 4 | tail -n 1 | sed 's/^ *//g')"
         GPG_KEY_ID="${GPG_KEY_FINGERPRINT: (-8)}"

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -35,7 +35,6 @@ jobs:
     
     - name: gpg key generation - transient
       run: |
-        export GNUPGHOME="$(mktemp -d)"
         cat >tempkey <<EOF
           %echo Generating a basic OpenPGP key
           Key-Type: DSA

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -35,6 +35,7 @@ jobs:
     
     - name: gpg key generation - transient
       run: |
+        export GNUPGHOME="/home/runner/.gnupg"
         cat >tempkey <<EOF
           %echo Generating a basic OpenPGP key
           Key-Type: DSA

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -70,7 +70,7 @@ jobs:
         ls *
         export GNUPGHOME="/home/runner/.gnupg"
         ls $GNUPGHOME
-        export GPG_KEY=$GPG_KEY_ID
+        export GPG_KEY=${{ env.GPG_KEY_ID }}
         bash $GITHUB_WORKSPACE/do-release.sh
       env:
         DRY_RUN: '1'

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -75,10 +75,10 @@ jobs:
         ASF_USERNAME: 'firstname'
         GIT_NAME: 'Firstname Lastname'
         GIT_EMAIL: 'j143+[bot]@protonmail.com'
-        GPG_KEY: 'j143+[bot]@protonmail.com'
+        GPG_KEY: '${{ env.GPG_KEY_ID }}'
         CORRECT_RELEASE_INFO: '1'
-        ASF_PASSWORD: asdfghjkl # wrong password, only to run this workflow
-        GPG_PASSPHRASE: asdfghjkl # wrong passphrase, only to run this workflow
+        ASF_PASSWORD: 'asdfghjkl' # wrong password, only to run this workflow
+        GPG_PASSPHRASE: 'asdfghjkl' # wrong passphrase, only to run this workflow
 
 #     - name: Build with Maven
 #       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -33,6 +33,26 @@ jobs:
    
     - run: printf "JAVA_HOME = $JAVA_HOME \n"
     
+    - name: gpg key generation - transient
+      run: >
+        export GNUPGHOME="$(mktemp -d)"
+        cat >tempkey <<EOF
+          %echo Generating a basic OpenPGP key
+          Key-Type: DSA
+          Key-Length: 1024
+          Subkey-Type: ELG-E
+          Subkey-Length: 1024
+          Name-Real: J143 Bot
+          Name-Comment: with stupid passphrase
+          Name-Email: j143+[bot]@protonmail.com
+          Expire-Date: 0
+          Passphrase: asdfghjkl
+          # Do a commit here, so that we can later print "done" :-)
+          %commit
+          %echo done
+        EOF
+        gpg --batch --generate-key tempkey
+    
     - name: Run invoke script
       run: |
         cd $GITHUB_WORKSPACE
@@ -49,8 +69,8 @@ jobs:
         GIT_NAME: 'Firstname Lastname'
         GIT_EMAIL: 'j143+[bot]@protonmail.com'
         CORRECT_RELEASE_INFO: '1'
-        ASF_PASSWORD: asdf # wrong password, only to run this workflow
-        GPG_PASSPHRASE: asdf # wrong passphrase, only to run this workflow
+        ASF_PASSWORD: asdfghjkl # wrong password, only to run this workflow
+        GPG_PASSPHRASE: asdfghjkl # wrong passphrase, only to run this workflow
 
 #     - name: Build with Maven
 #       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -34,8 +34,8 @@ jobs:
     - run: printf "JAVA_HOME = $JAVA_HOME \n"
     
     - name: gpg key generation - transient
-      run: >
-        export GNUPGHOME="$(mktemp -d)";
+      run: |
+        export GNUPGHOME="$(mktemp -d)"
         cat >tempkey <<EOF
           %echo Generating a basic OpenPGP key
           Key-Type: DSA
@@ -43,14 +43,14 @@ jobs:
           Subkey-Type: ELG-E
           Subkey-Length: 1024
           Name-Real: J143 Bot
-          Name-Comment: with stupid passphrase
+          Name-Comment: This is automation script
           Name-Email: j143+[bot]@protonmail.com
           Expire-Date: 0
           Passphrase: asdfghjkl
           # Do a commit here, so that we can later print "done" :-)
           %commit
           %echo done
-        EOF;
+        EOF
         gpg --batch --generate-key tempkey
     
     - name: Run invoke script

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -52,6 +52,10 @@ jobs:
         EOF
         gpg --batch --generate-key tempkey
     
+    - run: |
+        gpg --list-keys
+        GPG_KEY="$(gpg --list-keys | head -n 4 | tail -n 1 | sed 's/^ *//g')"
+    
     - name: Run invoke script
       run: |
         cd $GITHUB_WORKSPACE
@@ -67,7 +71,6 @@ jobs:
         ASF_USERNAME: 'firstname'
         GIT_NAME: 'Firstname Lastname'
         GIT_EMAIL: 'j143+[bot]@protonmail.com'
-        GPG_KEY: 'j143+[bot]@protonmail.com'
         CORRECT_RELEASE_INFO: '1'
         ASF_PASSWORD: asdfghjkl # wrong password, only to run this workflow
         GPG_PASSPHRASE: asdfghjkl # wrong passphrase, only to run this workflow

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -67,6 +67,7 @@ jobs:
         ASF_USERNAME: 'firstname'
         GIT_NAME: 'Firstname Lastname'
         GIT_EMAIL: 'j143+[bot]@protonmail.com'
+        GPG_KEY: 'j143+[bot]@protonmail.com'
         CORRECT_RELEASE_INFO: '1'
         ASF_PASSWORD: asdfghjkl # wrong password, only to run this workflow
         GPG_PASSPHRASE: asdfghjkl # wrong passphrase, only to run this workflow

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -70,7 +70,6 @@ jobs:
         ls *
         export GNUPGHOME="/home/runner/.gnupg"
         ls $GNUPGHOME
-        GPG_KEY_ID="$(gpg --list-keys | head -n 4 | tail -n 1 | sed 's/^ *//g')"
         export GPG_KEY=$GPG_KEY_ID
         bash $GITHUB_WORKSPACE/do-release.sh
       env:

--- a/create-tag.sh
+++ b/create-tag.sh
@@ -83,11 +83,20 @@ fi
 
 printf "Dry Run?: $dry_run \n"
 
+
+# When using gpg-plugin in conjunction with release plugin use 
+# 
+# $ mvn release:perform -Darguments=-Dgpg.passphrase=thephrase
+#
+# since the system properties of the current maven session are
+# not propagated to the forked session automatically.
+# 
+
 mvn --batch-mode -DdryRun="${dry_run}" -Dtag=$RELEASE_TAG release:prepare \
                  -Dresume=false \
                  -DreleaseVersion=$RELEASE_VERSION \
                  -DdevelopmentVersion=$NEXT_VERSION \
-                 ${GPG_OPTS}
+                 -Darguments="${GPG_OPTS}"
 
 
 # tag snapshot version after `mvn release:prepare`

--- a/create-tag.sh
+++ b/create-tag.sh
@@ -61,6 +61,8 @@ printf "$NEXT_VERSION"
 # options available at https://maven.apache.org/plugins/maven-gpg-plugin/sign-mojo.html
 GPG_OPTS="-Dgpg.homedir=$GNUPGHOME -Dgpg.keyname=$GPG_KEY -Dgpg.passphrase=$GPG_PASSPHRASE"
 
+printf "\n -Dgpg.homedir=$GNUPGHOME -Dgpg.keyname=$GPG_KEY -Dgpg.passphrase=$GPG_PASSPHRASE \n"
+
 # Tag release version before `mvn release:prepare`
 # tag python build
 # PySpark version info we use dev0 instead of SNAPSHOT to be closer
@@ -81,9 +83,10 @@ else
   dry_run=true
 fi
 
-printf "Dry Run?: $dry_run \n"
+printf "\n Dry Run?: $dry_run \n"
 
-
+# NOTE:
+# 
 # When using gpg-plugin in conjunction with release plugin use 
 # 
 # $ mvn release:perform -Darguments=-Dgpg.passphrase=thephrase

--- a/release-utils.sh
+++ b/release-utils.sh
@@ -143,7 +143,10 @@ get_release_info() {
     export GIT_NAME=$(read_config "Full name" "$GIT_NAME")
   fi
 
-  export GIT_EMAIL="$ASF_USERNAME@apache.org"
+  # git configuration info
+  if [ -z "$GIT_EMAIL" ]; then
+    export GIT_EMAIL="$ASF_USERNAME@apache.org"
+  fi
   
   # GPG key configuration info
   if [ -z "$GPG_KEY" ]; then

--- a/release-utils.sh
+++ b/release-utils.sh
@@ -144,7 +144,11 @@ get_release_info() {
   fi
 
   export GIT_EMAIL="$ASF_USERNAME@apache.org"
-  export GPG_KEY=$(read_config "GPG key" "$GIT_EMAIL")
+  
+  # GPG key configuration info
+  if [ -z "$GPG_KEY" ]; then
+    export GPG_KEY=$(read_config "GPG key" "$GIT_EMAIL")
+  fi
 
   cat <<EOF
 ================


### PR DESCRIPTION
For testing the sign functionality in the testing process the temporary (or transient) credentials are required.

1. create credentials
2. But, do not publish them to public server
3. make sure to `gpg --delete-keys`!
