### PR TITLE
build directory is provided in the target folder

### DIFF
--- a/release-build.sh
+++ b/release-build.sh
@@ -129,7 +129,7 @@ DEST_DIR_NAME="$PACKAGE_VERSION"
 # NOTE:
 # Build files will be saved to this folder.
 # This folder will be used by `publish-release`
-tmp_repo=$(mktemp -d systemds-repo-tmp-XXXXX)
+tmp_repo=$(mktemp -d target/systemds-repo-tmp-XXXXX)
 
 if [[ "$1" == "publish-release" ]]; then
 


### PR DESCRIPTION
Options:

1. Can you push the temp folder inside /target? ✔
2. Or you can rename that folder to just temp (or create your folder inside /temp), as /temp is gitignored.
3. Or you can add your temp folder to .git/info/exclude.




